### PR TITLE
FIX gold calculate algorithm when sheriff inspects

### DIFF
--- a/src/model/Game.cpp
+++ b/src/model/Game.cpp
@@ -829,19 +829,29 @@ int Game::calculatePenalty(const int sheriffSocketID, Bag &bag, bool isPass)
     else
     {
         /* Sheriff wants to check the bag */
+        bool isBluff = false;
+        int sheriffPenalty = 0;
+        int bagOwnerPenalty = 0;
         for (const auto &card : bag.mBagCards)
         {
             if (card != bag.mBagDeclared)
             {
-                sheriffPlayer.addGold(cardPenalty.at(card));
-                bagOwnerPlayer.subtractGold(cardPenalty.at(card));
+                isBluff = true;
+                bagOwnerPenalty += cardPenalty.at(card);
             }
             else
             {
-                sheriffPlayer.subtractGold(cardPenalty.at(card));
-                bagOwnerPlayer.addGold(cardPenalty.at(card));
+                sheriffPenalty += cardPenalty.at(card);
                 bagOwnerPlayer.addCardToGoods(card);
             }
+        }
+
+        if(isBluff){
+            sheriffPlayer.addGold(bagOwnerPenalty);
+            bagOwnerPlayer.subtractGold(bagOwnerPenalty);
+        }else{
+            sheriffPlayer.subtractGold(sheriffPenalty);
+            bagOwnerPlayer.addGold(sheriffPenalty);
         }
     }
     return -1;

--- a/test/test_checkBag.cpp
+++ b/test/test_checkBag.cpp
@@ -23,8 +23,8 @@ TEST(checkBagTest, TestSheriffCheck)
 
     curGame->calculatePenalty(sheriffSocketID, curBag, false);
 
-    EXPECT_EQ(curGame->getPlayer(merchantSocketID).getGold(), 50 - cardPenalty.at(SILK) * 3 + cardPenalty.at(CHICKEN) * 2);
-    EXPECT_EQ(curGame->getPlayer(sheriffSocketID).getGold(), 50 + cardPenalty.at(SILK) * 3 - cardPenalty.at(CHICKEN) * 2);
+    EXPECT_EQ(curGame->getPlayer(merchantSocketID).getGold(), 50 - cardPenalty.at(SILK) * 3);
+    EXPECT_EQ(curGame->getPlayer(sheriffSocketID).getGold(), 50 + cardPenalty.at(SILK) * 3);
     EXPECT_EQ(curGame->getPlayer(merchantSocketID).getGoods().at(CHICKEN), 2);
 }
 


### PR DESCRIPTION
@AnNguyen30072001 Please review this commit
**Test case 1:**
Player declared CHICKEN with 5 cards in bag : Chicken, Chicken, Silk, Silk, Silk
_Expected result:_
Player's gold will be 50 - 4 * 3 = 38 and the player trades 2 chicken cards successfully
Sheriff's gold will be 50 + 4 * 3 = 62
