### PR TITLE
IMPLEMENT After GAME_END, release threads of players

### DIFF
--- a/include/model/Constants.h
+++ b/include/model/Constants.h
@@ -1,0 +1,19 @@
+#ifndef CONSTANTS_H
+#define CONSTANTS_H
+
+#define LEFT_PILE 1
+#define RIGHT_PILE 2
+#define MAIN_DECK 3
+
+#define MAX_NUMBER_OF_PLAYER 6
+
+#define SHERIFF_TIMES_3_PLAYERS 3
+#define SHERIFF_TIMES_MORE_THAN_3_PLAYERS 2
+
+#define GAME_ID_DEFAULT 1234
+
+#define SERVER_PORT 8080
+#define MAX_CLIENTS 1000
+#define BUFFER_SIZE 1024
+
+#endif

--- a/include/model/Game.h
+++ b/include/model/Game.h
@@ -5,6 +5,7 @@
 #include "Player.h"
 #include "GameState.h"
 #include "Server.h"
+#include "Constants.h"
 
 #include <vector>
 #include <algorithm> // for std::shuffle
@@ -16,16 +17,6 @@
 #include <memory>
 #include <list>
 #include <utility>
-
-#define LEFT_PILE 1
-#define RIGHT_PILE 2
-#define MAIN_DECK 3
-
-#define MAX_NUMBER_OF_PLAYER 6
-#define SHERIFF_TIMES_3_PLAYERS 3
-#define SHERIFF_TIMES_MORE_THAN_3_PLAYERS 2
-
-#define GAME_ID_DEFAULT 1234
 
 struct Bag
 {

--- a/include/model/Server.h
+++ b/include/model/Server.h
@@ -10,12 +10,10 @@
 #include <unistd.h>
 #include <unordered_map>
 #include <json/json.h>
+#include <atomic>
 #include "Game.h"
 #include "GameState.h"
-
-#define SERVER_PORT 8080
-#define MAX_CLIENTS 1000
-#define BUFFER_SIZE 1024
+#include "Constants.h"
 
 enum ServerState
 {
@@ -30,6 +28,7 @@ public:
 
     void start();
     void stop();
+    void finish(const int gameID = GAME_ID_DEFAULT);
     void sendToClient(const std::string &message, const int socketID);
     void sendToAll(const std::string &message);
     void sendToAllExcept(const std::string &message, const int socketID);
@@ -54,11 +53,14 @@ private:
     std::vector<std::thread> mClientThreads;
     std::mutex mClientMutex;
 
-    std::unordered_map<int, std::unique_ptr<Game>> mGames;
+    std::unordered_map<int, std::shared_ptr<Game>> mGames;
     std::mutex mGamesMutex;
 
     std::unordered_map<int, int> mSocketIDToGame;
     std::mutex mSocketIDToGameMutex;
+
+    std::unordered_map<int, std::atomic<bool>> mClientRunningFlags;
+    std::mutex mClientFlagMutex;
 
     ServerState mServerState;
 };

--- a/src/model/Game.cpp
+++ b/src/model/Game.cpp
@@ -904,3 +904,8 @@ bool Game::tradeContrabandToCards(const int socketID)
     }
     return false;
 }
+
+int Game::getGameId() const
+{
+    return mGameId;
+}

--- a/src/model/Server.cpp
+++ b/src/model/Server.cpp
@@ -115,7 +115,7 @@ void Server::acceptClient()
             std::lock_guard<std::mutex> lock(mGamesMutex);
             if (mGames.find(GAME_ID_DEFAULT) == mGames.end())
             {
-                mGames.emplace(GAME_ID_DEFAULT, std::make_unique<Game>(GAME_ID_DEFAULT));
+                mGames.emplace(GAME_ID_DEFAULT, std::make_shared<Game>(GAME_ID_DEFAULT));
             }
             curGame = mGames[GAME_ID_DEFAULT].get();
         }
@@ -140,6 +140,7 @@ void Server::acceptClient()
         {
             std::lock_guard<std::mutex> lock(mClientMutex);
             mSocketIDToGame[client_socket] = GAME_ID_DEFAULT;
+            mClientRunningFlags[client_socket] = true;
             mClientThreads.emplace_back(&Server::handleClient, this, client_socket);
         }
     }
@@ -150,6 +151,15 @@ void Server::handleClient(int clientSocket)
     char buffer[BUFFER_SIZE];
     while (true)
     {
+        {
+            std::lock_guard<std::mutex> lock(mClientFlagMutex);
+            if (!mClientRunningFlags[clientSocket])
+            {
+                LOG(INFO, "Thread for client %d is asked to exit.", clientSocket);
+                break;
+            }
+        }
+
         int valRead = read(clientSocket, buffer, BUFFER_SIZE - 1); /* Ensure space for null-terminator */
         if (valRead < 0)
         {
@@ -181,12 +191,18 @@ void Server::handleClient(int clientSocket)
             break;
         }
 
-        Game *curGame = nullptr;
+        std::shared_ptr<Game> curGame;
         {
             std::lock_guard<std::mutex> lock(mClientMutex);
-            if (mSocketIDToGame.find(clientSocket) != mSocketIDToGame.end())
+            auto it = mSocketIDToGame.find(clientSocket);
+            if (it != mSocketIDToGame.end())
             {
-                curGame = mGames[mSocketIDToGame[clientSocket]].get();
+                std::lock_guard<std::mutex> lock2(mGamesMutex);
+                auto gameIt = mGames.find(it->second);
+                if (gameIt != mGames.end())
+                {
+                    curGame = gameIt->second;
+                }
             }
         }
 
@@ -296,4 +312,44 @@ void Server::closeConnection(const int socketID)
     }
     shutdown(socketID, SHUT_RDWR);
     close(socketID);
+}
+
+void Server::finish(const int gameID)
+{
+    std::lock_guard<std::mutex> lock(mGamesMutex);
+    if (mGames.find(gameID) == mGames.end())
+    {
+        LOG(ERROR, "Game with ID %d not found", gameID);
+        return;
+    }
+    Game *curGame = mGames[gameID].get();
+
+    LOG(INFO, "Finishing game with ID %d", gameID);
+    {
+        std::lock_guard<std::mutex> clientLock(mClientMutex);
+        for (auto it = mSocketIDToGame.begin(); it != mSocketIDToGame.end();)
+        {
+            if (it->second == gameID)
+            {
+                LOG(INFO, "Removing socketID %d from game %d", it->first, gameID);
+                {
+                    std::lock_guard<std::mutex> lock(mClientFlagMutex);
+                    if (mClientRunningFlags.find(it->first) != mClientRunningFlags.end())
+                    {
+                        mClientRunningFlags[it->first] = false;
+                    }
+                }
+                shutdown(it->first, SHUT_RDWR);
+                close(it->first);
+                it = mSocketIDToGame.erase(it);
+            }
+            else
+            {
+                ++it;
+            }
+        }
+    }
+
+    mGames.erase(gameID);
+    LOG(INFO, "Game with ID %d has been removed", gameID);
 }

--- a/src/state/GameEndedState.cpp
+++ b/src/state/GameEndedState.cpp
@@ -39,6 +39,7 @@ void GameEndedState::enterState(Game *curGame)
     endGameMessage["MessageType"] = "GAME_END";
     /* TODO: change state of all players and disconnect all of them */
     curGame->sendMessageToAll(jsonToString(endGameMessage));
+    Server::getInstance().finish(curGame->getGameId());
 }
 
 std::string GameEndedState::getStateName() const


### PR DESCRIPTION
**What & Why**
Implement feature after server sends PLAYER_END, players will be released from server and players can play again after pressing finish button
**Changes**
Added Constants.h to save parameter 
mClientRunningFlags indicates the state of thread
mGames to shared_ptr because of when curGame is erased, thread still have curGame pointer, which will cause server crashed (segmentation fault)
**Impact**
This will impact when player connects or clicks 'finish' button
**How to test**
Run Server then change mSheriffTimes to 0 => Server will immediately send GAME_END => click finish =>fill Name => connect again success