### PR TITLE
Implement reshuffle main deck if it runs out of cards

### DIFF
--- a/src/model/Game.cpp
+++ b/src/model/Game.cpp
@@ -242,41 +242,62 @@ bool Game::recreateDeck()
         return false;
     }
 
-    if (mLeftPile.size() + mRightPile.size() <= 10)
+    int appleCount = 48;
+    int cheeseCount = 36;
+    int breadCount = 36;
+    int chickenCount = 24;
+
+    int meadCount = 21;
+    int silkCount = 12;
+    int crossbowCount = 5;
+    int pepperCount = 22;
+
+    if (mNumberOfPlayers == 3)
     {
-        LOG(ERROR, "mLeftPile and mRightPile dont have enough cards");
-        return false;
+        breadCount -= 36;
+        pepperCount -= 4;
+        meadCount -= 5;
+        silkCount -= 3;
     }
 
-    while (!mLeftPile.empty())
+    // Add cards to the deck
+    for (int i = 0; i < appleCount; ++i)
     {
-        mDeck.emplace_back(mLeftPile.back());
-        mLeftPile.pop_back();
+        mDeck.emplace_back(CardName::APPLE);
     }
-
-    while (!mRightPile.empty())
+    for (int i = 0; i < cheeseCount; ++i)
     {
-        mDeck.emplace_back(mRightPile.back());
-        mRightPile.pop_back();
+        mDeck.emplace_back(CardName::CHEESE);
+    }
+    for (int i = 0; i < breadCount; ++i)
+    {
+        mDeck.emplace_back(CardName::BREAD);
+    }
+    for (int i = 0; i < chickenCount; ++i)
+    {
+        mDeck.emplace_back(CardName::CHICKEN);
+    }
+    for (int i = 0; i < pepperCount; ++i)
+    {
+        mDeck.emplace_back(CardName::PEPPER);
+    }
+    for (int i = 0; i < meadCount; ++i)
+    {
+        mDeck.emplace_back(CardName::MEAD);
+    }
+    for (int i = 0; i < silkCount; ++i)
+    {
+        mDeck.emplace_back(CardName::SILK);
+    }
+    for (int i = 0; i < crossbowCount; ++i)
+    {
+        mDeck.emplace_back(CardName::CROSSBOW);
     }
 
     // Shuffle the deck
     std::random_device rd;
     std::mt19937 g(rd());
     std::shuffle(mDeck.begin(), mDeck.end(), g);
-
-    // Take 5 random cards for mLeftPile and mRightPile
-    for (int i = 0; i < 5; ++i)
-    {
-        mLeftPile.push_back(mDeck.back());
-        mDeck.pop_back();
-    }
-
-    for (int i = 0; i < 5; ++i)
-    {
-        mRightPile.push_back(mDeck.back());
-        mDeck.pop_back();
-    }
 
     return true;
 }
@@ -286,8 +307,12 @@ CardName Game::withdrawDeck()
     std::lock_guard<std::mutex> lock(mDeckMutex);
     if (mDeck.empty())
     {
-        printf("mDeck is empty, can't withdraw!\n");
-        return INVALID_CARD;
+        if (!recreateDeck())
+        {
+            LOG(ERROR, "Recreate deck failed!");
+            return INVALID_CARD;
+        }
+        LOG(INFO, "mDeck is replenished!");
     }
     CardName topCardOfDeck = mDeck.back();
     LOG(DEBUG, "Withdraw Deck %s", cardNameToString.at(topCardOfDeck).c_str());

--- a/test/test_createAndSuffleDeck.cpp
+++ b/test/test_createAndSuffleDeck.cpp
@@ -119,16 +119,14 @@ TEST(createGameDetailsTest, testRecreateDeckSuccess1)
         curGame->insertPile(curGame->withdrawDeck(), LEFT_PILE);
     }
     EXPECT_TRUE(curGame->recreateDeck());
-    EXPECT_EQ(curGame->getDeck().size(), EXPECTED_DECK_SIZE_3PLAYER - 5 * 2);
-    EXPECT_EQ(curGame->getPile(LEFT_PILE).size(), 5);
-    EXPECT_EQ(curGame->getPile(RIGHT_PILE).size(), 5);
+    EXPECT_EQ(curGame->getDeck().size(), EXPECTED_DECK_SIZE_3PLAYER);
 }
 
 TEST(createGameDetailsTest, testRecreateDeckSuccess2)
 {
     Game *curGame = new Game(GAME_ID_DEFAULT);
 
-    for (int i = 0; i < 3; i++)
+    for (int i = 0; i < 4; i++)
     {
         std::string playerName = "Player" + std::to_string(i);
         int socketID = i;
@@ -142,16 +140,14 @@ TEST(createGameDetailsTest, testRecreateDeckSuccess2)
         curGame->insertPile(curGame->withdrawDeck(), RIGHT_PILE);
     }
     EXPECT_TRUE(curGame->recreateDeck());
-    EXPECT_EQ(curGame->getDeck().size(), EXPECTED_DECK_SIZE_3PLAYER - 5 * 2);
-    EXPECT_EQ(curGame->getPile(LEFT_PILE).size(), 5);
-    EXPECT_EQ(curGame->getPile(RIGHT_PILE).size(), 5);
+    EXPECT_EQ(curGame->getDeck().size(), EXPECTED_DECK_SIZE_4PLAYER);
 }
 
 TEST(createGameDetailsTest, testRecreateDeckSuccess3)
 {
     Game *curGame = new Game(GAME_ID_DEFAULT);
 
-    for (int i = 0; i < 3; i++)
+    for (int i = 0; i < 6; i++)
     {
         std::string playerName = "Player" + std::to_string(i);
         int socketID = i;
@@ -169,9 +165,28 @@ TEST(createGameDetailsTest, testRecreateDeckSuccess3)
         }
     }
     EXPECT_TRUE(curGame->recreateDeck());
-    EXPECT_EQ(curGame->getDeck().size(), EXPECTED_DECK_SIZE_3PLAYER - 5 * 2);
-    EXPECT_EQ(curGame->getPile(LEFT_PILE).size(), 5);
-    EXPECT_EQ(curGame->getPile(RIGHT_PILE).size(), 5);
+    EXPECT_EQ(curGame->getDeck().size(), EXPECTED_DECK_SIZE_4PLAYER);
+}
+
+TEST(createGameDetailsTest, testRecreateDeckSuccess4)
+{
+    Game *curGame = new Game(GAME_ID_DEFAULT);
+
+    for (int i = 0; i < 3; i++)
+    {
+        std::string playerName = "Player" + std::to_string(i);
+        int socketID = i;
+        curGame->addPlayer(socketID, GAME_ID_DEFAULT, playerName);
+    }
+
+    (void)curGame->createGameDetails();
+
+    while (!curGame->getDeck().empty())
+    {
+        CardName card = curGame->withdrawDeck();
+    }
+    EXPECT_TRUE(curGame->recreateDeck());
+    EXPECT_EQ(curGame->getDeck().size(), EXPECTED_DECK_SIZE_3PLAYER);
 }
 
 TEST(createGameDetailsTest, testRecreateDeckFail1)
@@ -190,26 +205,6 @@ TEST(createGameDetailsTest, testRecreateDeckFail1)
 }
 
 TEST(createGameDetailsTest, testRecreateDeckFail2)
-{
-    Game *curGame = new Game(GAME_ID_DEFAULT);
-
-    for (int i = 0; i < 3; i++)
-    {
-        std::string playerName = "Player" + std::to_string(i);
-        int socketID = i;
-        curGame->addPlayer(socketID, GAME_ID_DEFAULT, playerName);
-    }
-
-    (void)curGame->createGameDetails();
-
-    while (!curGame->getDeck().empty())
-    {
-        CardName card = curGame->withdrawDeck();
-    }
-    EXPECT_FALSE(curGame->recreateDeck());
-}
-
-TEST(createGameDetailsTest, testRecreateDeckFail3)
 {
     Game *curGame = new Game(GAME_ID_DEFAULT);
 


### PR DESCRIPTION
**What & Why**
Implement feature where the main deck runs out of cards while: 
- Dealing cards in the start of round.
- Player withdrawing cards in merchant turn.

**Changes**
Added mConfiscatedCards to store illegal cards the Sheriff has checked.
Modify recreateDeck(), send message "RECREATE_DECK" to all players.
For reponse message, add reponse case of "RECREATE_DECK" (in this case, I just implement it to log info, you should review this part with caution)

**Impact**
This impacts when the main deck is out of cards -> both left and right piles will be emptied, and main deck is replenished.

**How to test**
idk lol